### PR TITLE
established proxy to connect React to Express server

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "proxy": "http://localhost:3006",
   "eslintConfig": {
     "extends": "react-app"
   },


### PR DESCRIPTION
**What's In This Branch?**
I added a "proxy" to the `/client/package.json` file (line 19) to automatically run the express server. Now all you need to do to launch this app (in addition to having the database set up correctly) is run `npm start` from the /client directory in your terminal.