### PR TITLE
Feature/receipt closeout

### DIFF
--- a/client/src/components/Waitstaff/CurrentTablesComp.js
+++ b/client/src/components/Waitstaff/CurrentTablesComp.js
@@ -3,7 +3,7 @@ import React, {Component} from 'react';
 import Table from "react-bootstrap/Table";
 import axios from "axios";
 import { Link } from "react-router-dom";
-// import Button from "react-bootstrap/Button";
+import Button from "react-bootstrap/Button";
 
 class CurrentTablesComp extends Component {
   constructor() {
@@ -27,6 +27,11 @@ class CurrentTablesComp extends Component {
 
     // insert routing functionality here
   };
+
+  // newTableHandleClick = () => {
+  //   this.newReceiptNum();
+  //   console.log(this.state.nextReceiptNum);
+  // };
 
   // Function that queries the database to find all active tables (i.e. tables that have
   // not yet been closed out)
@@ -67,10 +72,12 @@ class CurrentTablesComp extends Component {
     fetch("http://localhost:3006/api/new-receipt-id")
     .then(response => response.json())
     .then(response => this.setState({ nextReceiptNum : response[0].receipt_id + 1 }))
+    .then(() => console.log((this.state.nextReceiptNum)));
   };
 
   componentDidMount() {
     this.getActiveTables();
+    this.newReceiptNum();
   }
   
   // renderTable function that accepts bill data and dynamically
@@ -95,6 +102,11 @@ class CurrentTablesComp extends Component {
             {this.state.activeOrders.map(this.renderTables)}
           </tbody>
         </Table>
+          <Link to={"/order/" + this.state.nextReceiptNum}>
+            <Button variant="success" size="lg" block>
+              New Table
+            </Button>
+          </Link>
       </div>
     )  
   }

--- a/client/src/components/Waitstaff/OrderPageMenuComp.js
+++ b/client/src/components/Waitstaff/OrderPageMenuComp.js
@@ -9,7 +9,8 @@ class MenuOrderComp extends Component {
     this.state = {
       menu: [],
       newOrders: [],
-      receipt_id: props.receiptID
+      receipt_id: props.receiptID,
+      inventory_stock: ""
     }
   };
 
@@ -39,10 +40,26 @@ class MenuOrderComp extends Component {
         "receipt_id": this.state.receipt_id,
         "InventoryMenuId": this.state.newOrders[i].menu_id
       };
-      // let menuItem = this.state.newOrders[i].menu_id;
+      this.inventoryUpdate(this.state.newOrders[i].menu_id);
       axios.post("http://localhost:3006/api/new-order", newOrderData);
       // axios.put("http://localhost:3006/api/inventory/" + menuItem);
     };
+  };
+
+  inventoryUpdate = (id) => {
+    let query="/api/stock/" + id;
+    console.log("Get Details test", query);
+    axios.get(query)
+    .then(response => this.setState({ inventory_stock : response.data}))
+    .then(() => {
+      let inventoryUpdate = {
+      "menu_id": id,
+      "stock": this.state.inventory_stock - 1
+      };
+      axios.put("/api/inventory/" + id, inventoryUpdate);
+    })
+    // .then(() => axios.put("/api/inventory/" + id, inventoryUpdate));
+    // .then(() => console.log("Inventory", this.state.inventory_stock));
   };
 
   // renderMenu function that takes in menu data (pulled from db in App.js) and dynamically

--- a/client/src/components/Waitstaff/OrderPageMenuComp.js
+++ b/client/src/components/Waitstaff/OrderPageMenuComp.js
@@ -39,7 +39,9 @@ class MenuOrderComp extends Component {
         "receipt_id": this.state.receipt_id,
         "InventoryMenuId": this.state.newOrders[i].menu_id
       };
-      axios.post("http://localhost:3006/api/new-order", newOrderData)
+      // let menuItem = this.state.newOrders[i].menu_id;
+      axios.post("http://localhost:3006/api/new-order", newOrderData);
+      // axios.put("http://localhost:3006/api/inventory/" + menuItem);
     };
   };
 

--- a/client/src/components/Waitstaff/ReceiptPageReceiptComp.js
+++ b/client/src/components/Waitstaff/ReceiptPageReceiptComp.js
@@ -30,6 +30,13 @@ class ReceiptPageReceiptComp extends Component {
     this.setState({totalCheck: tab});
     console.log(this.state.totalCheck);
   };
+
+  // OnClick function for Close Out button to update receipt in Orders table by setting
+  // isClosedOut === true
+  handleClick = () => {
+    let updateURL = "/api/closeout/" + this.props.receiptID;
+    axios.put(updateURL);
+  };
    
   componentDidMount() {
     this.currentBill();
@@ -57,7 +64,7 @@ class ReceiptPageReceiptComp extends Component {
         <div>
         </div>
         <h3>Total: ${this.state.totalCheck}</h3>
-        <Button variant="success" size="lg" block>
+        <Button variant="success" size="lg" block onClick={this.handleClick}>
           Cash Out
         </Button>
       </div>

--- a/models/inventory.js
+++ b/models/inventory.js
@@ -36,7 +36,7 @@ module.exports = function(sequelize, DataTypes) {
       updatedAt: {
         type: DataTypes.DATE,
         allowNull: false,
-        defaultValue: sequelize.literal("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+        defaultValue: sequelize.literal("CURRENT_TIMESTAMP")
       }
     },
     {

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -105,6 +105,14 @@ router.use("/api/menu", function(req, res) {
     });
   });
 
+  // PUT route for waitstaff to close out a table in database
+  router.use("/api/closeout/:receipt", function(req, res) {
+    db.Order.update({
+      isClosedOut: true
+    }, {where: {receipt_id: req.params.receipt }
+    });
+  });
+
   // // GET route for waitstaff to calculate current bill by receipt_id
   // app.get("/api/current-bill/:receipt-id", function(req, res) {
   //   connection.query(SELECT_BY_ID, {receipt_id: req.params.receipt-id}, function(err, queryResults) {

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -113,6 +113,27 @@ router.use("/api/menu", function(req, res) {
     });
   });
 
+  // PUT route to decrement inventory table in db based on orders added
+  router.use("/api/inventory/:menuID", function(req, res) {
+    db.Inventory.findOne({
+      where: { 
+        menu_id: req.params.menuID
+      }
+    }).then(dish => {
+      return dish.decrement("1"); // assumes `option` always exists
+    }).then(dish => {
+      return dish.reload();
+    }).then(dish => {
+      res.json(dish);
+    });
+    
+    
+    // db.Inventory.decrement([
+    //   "stock", "1"
+    // ],{where: {menu_id: req.params.menuID}}
+    // );
+  });
+
   // // GET route for waitstaff to calculate current bill by receipt_id
   // app.get("/api/current-bill/:receipt-id", function(req, res) {
   //   connection.query(SELECT_BY_ID, {receipt_id: req.params.receipt-id}, function(err, queryResults) {

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -38,6 +38,17 @@ router.use("/api/menu", function(req, res) {
     });
   });
 
+  // GET route for waitstaff to pull active inventory
+  router.use("/api/stock/:id", function(req, res) {
+    db.Inventory.findOne({
+      where: {
+        menu_id: req.params.id
+      }
+    }).then(function(billItem) {
+      res.json(billItem.stock);
+    });
+  });
+
   // GET route for waitstaff and manager pages to generate bills by receipt_id
   router.use("/api/get-bill/:receipt", function(req, res) {
     db.Inventory.findAll({
@@ -109,30 +120,37 @@ router.use("/api/menu", function(req, res) {
   router.use("/api/closeout/:receipt", function(req, res) {
     db.Order.update({
       isClosedOut: true
-    }, {where: {receipt_id: req.params.receipt }
+    }, {where: {receipt_id: req.params.receipt}
+    });
+  });
+
+
+  // PUT route to decrement inventory table in db
+  router.use("/api/inventory/:menuID", function(req, res) {
+    db.Inventory.update(req.body, {where: {menu_id: req.params.menuID }
     });
   });
 
   // PUT route to decrement inventory table in db based on orders added
-  router.use("/api/inventory/:menuID", function(req, res) {
-    db.Inventory.findOne({
-      where: { 
-        menu_id: req.params.menuID
-      }
-    }).then(dish => {
-      return dish.decrement("1"); // assumes `option` always exists
-    }).then(dish => {
-      return dish.reload();
-    }).then(dish => {
-      res.json(dish);
-    });
+  // router.use("/api/inventory/:menuID", function(req, res) {
+  //   db.Inventory.findOne({
+  //     where: { 
+  //       menu_id: req.params.menuID
+  //     }
+  //   }).then(dish => {
+  //     return dish.decrement("1"); // assumes `option` always exists
+  //   }).then(dish => {
+  //     return dish.reload();
+  //   }).then(dish => {
+  //     res.json(dish);
+  //   });
     
     
-    // db.Inventory.decrement([
-    //   "stock", "1"
-    // ],{where: {menu_id: req.params.menuID}}
-    // );
-  });
+  //   // db.Inventory.decrement([
+  //   //   "stock", "1"
+  //   // ],{where: {menu_id: req.params.menuID}}
+  //   // );
+  // });
 
   // // GET route for waitstaff to calculate current bill by receipt_id
   // app.get("/api/current-bill/:receipt-id", function(req, res) {


### PR DESCRIPTION
Was just doing some project work. I need to review everything to ensure it's all working as intended, but my open branch (`feature/receipt-closeout`) currently includes the following functionality:
1) New Tables. Waitstaff can now click on a "New Table" button and add a new receipt_id (and corresponding orders) to the database
2) Inventory update: When waitstaff clicks "Order" on the Order page, the inventory is now decremented accordingly
3) Close Out: When waitstaff click "Close Out" on the Receipt page, it now updates the database to change that table to isClosedOut === true, which means that table no longer shows up in the current tables but now shows up in the "Closed Checks" part of the Manager Page