### PR TITLE
added heroku build route to server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -43,9 +43,9 @@ if (process.env.NODE_ENV === "production") {
 // API Routes
 app.use(apiRoutes);
 
-//   app.get('*', (req, res) => {
-//   res.sendFile(path.join(__dirname+'/client/public/index.html'));
-// })
+app.get("*", (req, res) => {
+  res.sendFile(path.resolve(__dirname + "/client/build/index.html"));
+})
 
 
 // Starting the server, syncing our models ------------------------------------/


### PR DESCRIPTION
Added the following code to `server.js` so that the app works correctly when deployed to Heroku:

`app.get("*", (req, res) => {
  res.sendFile(path.resolve(__dirname + "/client/build/index.html"));
})`