### PR TITLE
Feature/redirects

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -7,7 +7,8 @@ import Login from "./pages/Login"
 import Waitstaff1CurTablesPage from "./pages/Waitstaff1CurTablesPage";
 import Waitstaff2OrderPage from "./pages/Waitstaff2OrderPage";
 import Waitstaff3ReceiptPage from "./pages/Waitstaff3ReceiptPage";
-import ManagerPage from "./pages/ManagerPage"
+import ManagerPage from "./pages/ManagerPage";
+import NoMatch from "./pages/NoMatch";
 import './App.css';
 
 class App extends Component {
@@ -27,6 +28,7 @@ class App extends Component {
             <Route exact path="/order/:receiptNum" component={Waitstaff2OrderPage} />
             <Route exact path="/receipt/:receiptNum" component={Waitstaff3ReceiptPage} />
             <Route exact path="/manager" component={ManagerPage} />
+            <Route component={NoMatch} />
           {/* <div> */}
             {/* Routing will go here */}
             {/* <LandingPage /> */}

--- a/client/src/components/Waitstaff/OrderPageMenuComp.js
+++ b/client/src/components/Waitstaff/OrderPageMenuComp.js
@@ -69,7 +69,7 @@ class MenuOrderComp extends Component {
   // renderCart function that takes in menu data and dynamically
   // generates HTML to insert them into the table coded by this component.
   // We call this function as the callback to the map function on line 95 below.
-  renderCart = ({menu_id, menu_name}) => <tr key={menu_id}><td>{menu_id}</td><td>{menu_name}</td><td></td></tr>;
+  renderCart = ({menu_id, menu_name}, index) => <tr key={index}><td>{menu_id}</td><td>{menu_name}</td></tr>;
   
   componentDidMount() {
     this.getMenu();
@@ -110,7 +110,6 @@ class MenuOrderComp extends Component {
             <tr>
               <th>Menu ID</th>
               <th>Menu Item</th>
-              <th>Remove?</th>
             </tr>
           </thead>
           <tbody>

--- a/client/src/components/Waitstaff/OrderPageMenuComp.js
+++ b/client/src/components/Waitstaff/OrderPageMenuComp.js
@@ -1,5 +1,6 @@
 import React, {Component} from "react";
 import {Table, Button } from "react-bootstrap";
+import  {Redirect} from "react-router-dom";
 import axios from "axios";
 
 class MenuOrderComp extends Component {
@@ -9,7 +10,8 @@ class MenuOrderComp extends Component {
       menu: [],
       newOrders: [],
       receipt_id: props.receiptID,
-      inventory_stock: ""
+      inventory_stock: "",
+      toCurrentTables: false
     }
   };
 
@@ -40,9 +42,11 @@ class MenuOrderComp extends Component {
         "InventoryMenuId": this.state.newOrders[i].menu_id
       };
       this.inventoryUpdate(this.state.newOrders[i].menu_id);
-      axios.post("http://localhost:3006/api/new-order", newOrderData);
+      axios.post("http://localhost:3006/api/new-order", newOrderData)
+      .then(()=> this.setState({toCurrentTables: true}))
       // axios.put("http://localhost:3006/api/inventory/" + menuItem);
     };
+
   };
 
   inventoryUpdate = (id) => {
@@ -76,6 +80,11 @@ class MenuOrderComp extends Component {
   }
 
   render() {
+
+    if (this.state.toCurrentTables === true) {
+      return <Redirect to="/current-tables" />
+    }
+
     return (
       <div>
         <h3>

--- a/client/src/components/Waitstaff/OrderPageMenuComp.js
+++ b/client/src/components/Waitstaff/OrderPageMenuComp.js
@@ -42,7 +42,7 @@ class MenuOrderComp extends Component {
         "InventoryMenuId": this.state.newOrders[i].menu_id
       };
       this.inventoryUpdate(this.state.newOrders[i].menu_id);
-      axios.post("http://localhost:3006/api/new-order", newOrderData)
+      axios.post("/api/new-order", newOrderData)
       .then(()=> this.setState({toCurrentTables: true}))
       // axios.put("http://localhost:3006/api/inventory/" + menuItem);
     };
@@ -100,15 +100,6 @@ class MenuOrderComp extends Component {
           </thead>
           <tbody>
             {this.state.menu.map(this.renderMenu)}
-            {/* <tr>
-              <td>Menu Item </td>
-              <td>Add
-                <div id='counter'>{this.state.counter}
-                  <button onClick = {this.increment}> Add 1 </button> 
-                  <button onClick = {this.decrement}> Minus 1 </button> 
-                </div>
-              </td>
-            </tr> */}
           </tbody>
         </Table>
         <h3>

--- a/client/src/components/Waitstaff/ReceiptPageReceiptComp.js
+++ b/client/src/components/Waitstaff/ReceiptPageReceiptComp.js
@@ -15,7 +15,7 @@ class ReceiptPageReceiptComp extends Component {
   
   // Function that queries the db again to retrieve full bill data for each receipt_id
   currentBill = () => {
-    let queryString = "http://localhost:3006/api/get-bill/" + this.props.receiptID;
+    let queryString = "/api/get-bill/" + this.props.receiptID;
     axios.get(queryString)
     .then(response => this.setState({receipt_items:response.data}))
     .then(() => console.log(this.state.receipt_items))

--- a/client/src/components/Waitstaff/ReceiptPageReceiptComp.js
+++ b/client/src/components/Waitstaff/ReceiptPageReceiptComp.js
@@ -1,5 +1,6 @@
 import React, {Component} from "react";
 import { Table, Button, Row } from "react-bootstrap";
+import  {Redirect} from "react-router-dom";
 import axios from "axios";
 
 class ReceiptPageReceiptComp extends Component {
@@ -7,7 +8,8 @@ class ReceiptPageReceiptComp extends Component {
     super();
     this.state = {
       receipt_items: [],
-      totalCheck: ""
+      totalCheck: "",
+      toCurrentTables: false
     }
   };
   
@@ -34,8 +36,10 @@ class ReceiptPageReceiptComp extends Component {
   // OnClick function for Close Out button to update receipt in Orders table by setting
   // isClosedOut === true
   handleClick = () => {
-    let updateURL = "/api/closeout/" + this.props.receiptID;
+    let receipt_id = this.props.receiptID;
+    let updateURL = "/api/closeout/" + receipt_id;
     axios.put(updateURL);
+    this.setState({toCurrentTables: true});
   };
    
   componentDidMount() {
@@ -45,6 +49,12 @@ class ReceiptPageReceiptComp extends Component {
   renderReceipt = ({menu_id, menu_name, menu_price}) => <tr key={menu_id}><td>{menu_name}</td><td>${menu_price}</td></tr>;
   
   render() {
+
+    if (this.state.toCurrentTables === true) {
+      console.log("TRUE");
+      return <Redirect to="/current-tables" />
+    }
+
     return (
       <div>
         <br />

--- a/client/src/pages/ManagerPage.js
+++ b/client/src/pages/ManagerPage.js
@@ -17,7 +17,7 @@ class ManagerPage extends Component {
   // Function that queries the database to find all active tables (i.e. tables that have
   // not yet been closed out)
   getActiveTables = () => {
-    fetch("http://localhost:3006/api/active-tables")
+    fetch("/api/active-tables")
     .then(response => response.json())
     .then(response => {
       for (let a=0; a<response.length; a++) {
@@ -32,7 +32,7 @@ class ManagerPage extends Component {
   activeBill = () => {
     for (let m=0; m<this.state.activeOrders.length; m++) {
       let receiptID = this.state.activeOrders[m].receipt_id;
-      let queryString = "http://localhost:3006/api/get-bill/" + receiptID;
+      let queryString = "/api/get-bill/" + receiptID;
       axios.get(queryString)
       .then(response => this.calculateBill(response.data, m))
     }
@@ -52,7 +52,7 @@ class ManagerPage extends Component {
 
   // Function that queries the database to find all closed tables
   getClosedTables = () => {
-    fetch("http://localhost:3006/api/closed-tables")
+    fetch("/api/closed-tables")
     .then(response => response.json())
     .then(response => {
       for (let b=0; b<response.length; b++) {
@@ -65,7 +65,7 @@ class ManagerPage extends Component {
   closedBill = () => {
     for (let n=0; n<this.state.closedOrders.length; n++) {
       let receiptID = this.state.closedOrders[n].receipt_id;
-      let queryString = "http://localhost:3006/api/get-bill/" + receiptID;
+      let queryString = "/api/get-bill/" + receiptID;
       axios.get(queryString)
       .then(response => this.calculateCheck(response.data, n))
     }

--- a/client/src/pages/NoMatch.js
+++ b/client/src/pages/NoMatch.js
@@ -1,0 +1,14 @@
+import React from "react";
+import {Button} from "react-bootstrap";
+import {Link} from "react-router-dom";
+
+function NoMatch() {
+  return (
+    <div>
+      <h1>Page Not Found</h1>
+      <Link to="/"><Button variant="success" size="lg" block>Go Back to Landing Page</Button></Link>
+    </div>
+  );
+}
+
+export default NoMatch;


### PR DESCRIPTION
### What's in This Branch?

- Removed the "Removed" button from the Orders page

- Fixed the console errors that popped up when you tried to add duplicate items to the order (e.g. adding two Salmons)

- Added some redirects from the Order and Receipt pages to take waitstaff back to current-tables page.

- Added a very ugly 404 route doesn't exist page with a button that takes them back to the landing page.

- (hopefully) fixed the API routes throughout the app